### PR TITLE
Fix for supporting hibernate proxies

### DIFF
--- a/src/groovy/org/grails/plugins/rest/NumberToDomainInstanceEditor.groovy
+++ b/src/groovy/org/grails/plugins/rest/NumberToDomainInstanceEditor.groovy
@@ -11,7 +11,7 @@ public class NumberToDomainInstanceEditor extends PropertyEditorSupport {
 
     @Override
     public void setValue(Object value) {
-        if (value.class == domainClass)
+        if (domainClass.isAssignableFrom(value.class))
             super.setValue(value)
         else if (value instanceof Number) {
             def instance = domainClass.get(value)


### PR DESCRIPTION
Sometimes the objects that are obtained from the database are hibernate proxies, which are subclasses of the actual domain classes. This change is needed to properly handle these proxies.
